### PR TITLE
Cleanup: use operator predicates in waffle rather than ad-hoc matches.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,9 +1879,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waffle"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5402cb0d627f0f651056685f4785396aedec91c6f00fe969c6a40edaeaa5c822"
+checksum = "9ed8dea2ab4253b7b2c6cb253cb1f0f149330b218ed9b0ac1c3c13753da33b51"
 dependencies = [
  "addr2line",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 exclude = ["/npm", "/ci"]
 
 [dependencies]
-waffle = "0.1.0"
+waffle = "0.1.1"
 anyhow = "1.0"
 structopt = "0.3"
 log = "0.4"


### PR DESCRIPTION
Uses the operator helpers added in bytecodealliance/waffle#3. Cleans up the definition of operators that can be removed during DCE, for example, with a much clearer set of reasons.