### PR TITLE
Fix NPM readme to reference new repo location

### DIFF
--- a/npm/weval/README.md
+++ b/npm/weval/README.md
@@ -2,17 +2,17 @@
 
 > Prebuilt weval binaries available via npm
 
-See the [weval repository](https://github.com/cfallin/weval) for more details.
+See the [weval repository](https://github.com/bytecodealliance/weval) for more details.
 
 ## API
 
 ```
-$ npm install --save @cfallin/weval
+$ npm install --save @bytecodealliance/weval
 ```
 
 ```js
 const execFile = require('child_process').execFile;
-const weval = require('@cfallin/weval');
+const weval = require('@bytecodealliance/weval');
 
 execFile(weval, ['-w', '-i', 'snapshot.wasm', '-o', 'wevaled.wasm'], (err, stdout) => {
 	console.log(stdout);


### PR DESCRIPTION
Failed to grep for `cfallin` in all the documentation places!