### PR TITLE
Version 0.3.2, and a few URL fixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "weval"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "weval"
 description = "The WebAssembly partial evaluator"
 repository = "https://github.com/bytecodealliance/weval"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Chris Fallin <chris@cfallin.org>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2021"

--- a/npm/weval/index.js
+++ b/npm/weval/index.js
@@ -10,7 +10,7 @@ import decompressTar from 'decompress-tar';
 import xz from '@napi-rs/lzma/xz';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const TAG = "v0.3.1";
+const TAG = "v0.3.2";
 
 async function getWeval() {
     const knownPlatforms = {

--- a/npm/weval/package.json
+++ b/npm/weval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytecodealliance/weval",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The WebAssembly partial evaluator",
   "type": "module",
   "scripts": {
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cfallin/weval.git"
+    "url": "git+https://github.com/bytecodealliance/weval.git"
   },
   "bugs": {
-    "url": "https://github.com/cfallin/weval/issues"
+    "url": "https://github.com/bytecodealliance/weval/issues"
   },
-  "homepage": "https://github.com/cfallin/weval#readme"
+  "homepage": "https://github.com/bytecodealliance/weval#readme"
 }


### PR DESCRIPTION
Let's release another point-release with #9 (updates to the npm README to point to the new BA-hosted repo location). This also updates a few URLs in the npm `package.json` with the old location.